### PR TITLE
fix ninjs formatter

### DIFF
--- a/server/anp/formatters/custom_ninjs_formatter.py
+++ b/server/anp/formatters/custom_ninjs_formatter.py
@@ -1,11 +1,25 @@
 
+import superdesk
+
 from superdesk.publish.formatters import NINJSFormatter
 
 
 class CustomNINJSFormatter(NINJSFormatter):
 
-    direct_copy_properties = NINJSFormatter.direct_copy_properties + ('family_id',)
-
     def __init__(self):
         super().__init__()
         self.format_type = 'custom_ninjs'
+
+    def _transform_to_ninjs(self, article, subscriber, recursive=True):
+        ninjs = super()._transform_to_ninjs(article, subscriber, recursive=recursive)
+
+        orig = article
+        for i in range(0, 50):  # just in case
+            if orig.get('rewrite_of'):
+                orig = superdesk.get_resource_service('archive').find_one(req=None, _id=orig['rewrite_of'])
+                continue
+            elif orig != article:
+                ninjs['original'] = orig['_id']
+            break
+
+        return ninjs

--- a/server/tests/custom_ninjs_formatter_test.py
+++ b/server/tests/custom_ninjs_formatter_test.py
@@ -1,18 +1,36 @@
 
 import unittest
 
+from superdesk.tests import TestCase
 from anp.formatters import CustomNINJSFormatter
 
 
-class CustomNINJSFormatterTestCase(unittest.TestCase):
-
-    def test_family_id(self):
-        item = {'language': 'en', 'family_id': 'foo', 'type': 'text', 'copyrightholder': 'cp'}
-        formatter = CustomNINJSFormatter()
-        ninjs = formatter._transform_to_ninjs(item, {})
-        self.assertEqual(ninjs['family_id'], item['family_id'])
-        self.assertEqual(ninjs['language'], item['language'])
+class MetadataTestCase(unittest.TestCase):
 
     def test_can_format(self):
         formatter = CustomNINJSFormatter()
         self.assertTrue(formatter.can_format('custom_ninjs', {}))
+
+
+class CustomNINJSFormatterTestCase(TestCase):
+
+    def test_family_id(self):
+        items = [
+            {'_id': 'orig'},
+            {'_id': 'next', 'rewrite_of': 'orig'},
+            {'_id': 'last', 'rewrite_of': 'next'},
+        ]
+
+        for item in items:
+            item.update({'language': 'en', 'type': 'text', 'copyrightholder': 'foo'})
+
+        self.app.data.insert('archive', items)
+
+        formatter = CustomNINJSFormatter()
+
+        for i, item in enumerate(items):
+            ninjs = formatter._transform_to_ninjs(items[i], {})
+            if i == 0:
+                self.assertIsNone(ninjs.get('original'))
+            else:
+                self.assertEqual('orig', ninjs['original'])


### PR DESCRIPTION
family_id didn't work for duplicates,
so resolving original via traversing rewrites

SDESK-5085